### PR TITLE
Fixed _has_dns_propagated not returning False when failed

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -70,6 +70,8 @@ def _has_dns_propagated(name, token):
                 
     except dns.exception.DNSException as e:
         logger.debug(" + {0}. Retrying query...".format(e))
+        
+    return False
 
 
 # https://api.cloudflare.com/#zone-list-zones


### PR DESCRIPTION
The hook currently doesn't work for me. The issue seems to be with `_has_dns_propagated`. It doesn't return False when failed. As `create_all_txt_records` specifically checks for `== False`, the hook assumes the DNS has propagated.